### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/gcp-service-catalog-crawl.yml
+++ b/.github/workflows/gcp-service-catalog-crawl.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.4' # GOVERSION
 

--- a/.github/workflows/gcp-service-catalog-generate.yaml
+++ b/.github/workflows/gcp-service-catalog-generate.yaml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.4' # GOVERSION
 


### PR DESCRIPTION
Pin `actions/setup-go` and Docker actions to their resolved commit SHAs. These tags resolve to the exact same commits already pinned in 69+ other repos in the org.